### PR TITLE
ipod4g: Log originating core for memory requests

### DIFF
--- a/clicky-core/src/devices/platform/pp.rs
+++ b/clicky-core/src/devices/platform/pp.rs
@@ -48,4 +48,13 @@ pub mod common {
         Cpu,
         Cop,
     }
+
+    impl std::fmt::Display for CpuId {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            match self {
+                CpuId::Cpu => write!(f, "CPU"),
+                CpuId::Cop => write!(f, "COP"),
+            }
+        }
+    }
 }

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -195,7 +195,7 @@ impl Ipod4g {
                     MemExceptionCtx {
                         pc: cpu.reg_get(cpu.mode(), reg::PC),
                         access,
-                        in_device: format!("{}", devices.probe(access.offset)),
+                        in_device: format!("{}, {}", cpuid, devices.probe(access.offset)),
                     },
                 )?;
             }


### PR DESCRIPTION
Helps understanding whether some memory requests originate from CPU or COP.

Example output:

```
 ERROR MMIO > [pc 0x00008878][addr 0x6000c000][CPU, Cache Controller > Control] stubbed write (0x00000000)
 ERROR MMIO > [pc 0x00008878][addr 0x6000c000][COP, Cache Controller > Control] stubbed write (0x00000000
```