### PR TITLE
devcon: Log reset/enable events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,8 @@ dependencies = [
  "pin-utils",
  "relativity",
  "static_assertions",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -1066,6 +1068,24 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "strum"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530efb820d53b712f4e347916c5e7ed20deb76a4f0457943b3182fb889b06d2c"
+
+[[package]]
+name = "strum_macros"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/clicky-core/Cargo.toml
+++ b/clicky-core/Cargo.toml
@@ -32,6 +32,11 @@ async-channel = "1.4"
 blocking = "0.5"
 futures-executor = { version = "0.3", features = ["thread-pool"] } # TEMP
 pin-utils = "0.1"
+
+# enum
+strum = "0.17.1"
+strum_macros = "0.17.1"
+
 [dependencies.futures]
 version = "0.3"
 default-features = false


### PR DESCRIPTION
Logs when a device is being reset or enabled. So far I've noticed that bit 30 of device enable register hasn't been documented yet. Given the logs, I'd assume this is CPU cache enable:

![image](https://github.com/daniel5151/clicky/assets/25333063/58cfaee8-05c7-41c9-9562-1435460e6158)
