### PR TITLE
Make clicky able to partially boot into iPodLinux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,8 +44,7 @@ dependencies = [
 [[package]]
 name = "armv4t_emu"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df73307140e36ebb0c4298da3c3abf1d90b78b3232d50f091b3b2f46a05689f"
+source = "git+https://github.com/daniel5151/armv4t_emu.git#9647abdaebc5be076fe5ce92f4fb4254d305c577"
 dependencies = [
  "log",
 ]

--- a/clicky-core/Cargo.toml
+++ b/clicky-core/Cargo.toml
@@ -24,7 +24,7 @@ static_assertions = "1.1"
 thiserror = "1.0"
 
 # emulation related
-armv4t_emu = "0.1"
+armv4t_emu = { git = "https://github.com/daniel5151/armv4t_emu.git" }
 gdbstub = "0.4"
 
 # async/await

--- a/clicky-core/src/devices/generic/ide/mod.rs
+++ b/clicky-core/src/devices/generic/ide/mod.rs
@@ -87,6 +87,8 @@ enum IdeCmd {
     WriteDMA = 0xca,
     WriteDMANoRetry = 0xcb,
 
+    InitializeDriveParameters = 0x91,
+
     Sleep = 0x99,
     SleepAlt = 0xe6,
 
@@ -685,6 +687,10 @@ impl IdeDrive {
                 (self.reg.status).set_bit(reg::STATUS::BSY, false);
 
                 self.irq.assert();
+                Ok(())
+            }
+
+            InitializeDriveParameters => {
                 Ok(())
             }
         }

--- a/clicky-core/src/devices/generic/ide/mod.rs
+++ b/clicky-core/src/devices/generic/ide/mod.rs
@@ -691,6 +691,8 @@ impl IdeDrive {
             }
 
             InitializeDriveParameters => {
+                (self.reg.status).set_bit(reg::STATUS::BSY, false);
+                self.irq.assert();
                 Ok(())
             }
         }

--- a/clicky-core/src/devices/platform/pp/evp.rs
+++ b/clicky-core/src/devices/platform/pp/evp.rs
@@ -53,14 +53,14 @@ impl Device for Evp {
 impl Memory for Evp {
     fn r32(&mut self, offset: u32) -> MemResult<u32> {
         match offset {
-            0x0 => Err(StubRead(Error, self.reset_vec)),
-            0x4 => Err(StubRead(Error, self.undefined_instr_vec)),
-            0x8 => Err(StubRead(Error, self.soft_irq_vec)),
-            0xC => Err(StubRead(Error, self.prefetch_abrt_vec)),
-            0x10 => Err(StubRead(Error, self.data_abrt_vec)),
-            0x14 => Err(StubRead(Error, self.reserved_vec)),
-            0x18 => Err(StubRead(Error, self.normal_irq_vec)),
-            0x1C => Err(StubRead(Error, self.high_priority_irq_vec)),
+            0x0 => Ok(self.reset_vec),
+            0x4 => Ok(self.undefined_instr_vec),
+            0x8 => Ok(self.soft_irq_vec),
+            0xC => Ok(self.prefetch_abrt_vec),
+            0x10 => Ok(self.data_abrt_vec),
+            0x14 => Ok(self.reserved_vec),
+            0x18 => Ok(self.normal_irq_vec),
+            0x1C => Ok(self.high_priority_irq_vec),
             _ => Err(Unexpected),
         }
     }

--- a/clicky-core/src/devices/platform/pp/gpio.rs
+++ b/clicky-core/src/devices/platform/pp/gpio.rs
@@ -152,8 +152,8 @@ impl Memory for GpioPort {
     }
 
     fn w32(&mut self, offset: u32, val: u32) -> MemResult<()> {
-        // it's an 8-bit interface
-        let val = val.trunc_to_u8()?;
+        // it's an 8-bit interface, but everyone does 32 bits accesses to it (eg. ipodloader2's keypad.c:543)
+        let val = val as u8;
 
         match offset {
             0x00 => self.enable = val,

--- a/clicky-core/src/devices/platform/pp/memcon.rs
+++ b/clicky-core/src/devices/platform/pp/memcon.rs
@@ -245,6 +245,10 @@ impl Device for MemConImpl {
 }
 
 impl Memory for MemConImpl {
+    fn x32(&mut self, offset: u32) -> MemResult<u32> {
+        
+    }
+
     fn r32(&mut self, offset: u32) -> MemResult<u32> {
         match offset {
             0x0000..=0x1fff => Err(StubRead(Error, self.cache_data[offset as usize])),

--- a/clicky-core/src/devices/util/arcmutex.rs
+++ b/clicky-core/src/devices/util/arcmutex.rs
@@ -70,4 +70,12 @@ impl<D: Memory> Memory for ArcMutexDevice<D> {
     fn w16(&mut self, offset: u32, val: u16) -> MemResult<()> {
         self.device.lock().unwrap().w16(offset, val)
     }
+
+    fn x16(&mut self, offset: u32) -> MemResult<u16> {
+        self.device.lock().unwrap().x16(offset)
+    }
+
+    fn x32(&mut self, offset: u32) -> MemResult<u32> {
+        self.device.lock().unwrap().x32(offset)
+    }
 }

--- a/clicky-core/src/devices/util/mem_sniffer.rs
+++ b/clicky-core/src/devices/util/mem_sniffer.rs
@@ -45,6 +45,18 @@ macro_rules! impl_memsniff_w {
     };
 }
 
+macro_rules! impl_memsniff_x {
+    ($fn:ident, $ret:ty) => {
+        fn $fn(&mut self, addr: u32) -> MemResult<$ret> {
+            let ret = self.mem.$fn(addr)?;
+            if self.addrs.contains(&addr) {
+                (self.on_access)(ret.to_memaccess(addr, MemAccessKind::Execute));
+            }
+            Ok(ret)
+        }
+    };
+}
+
 impl<'a, M: Device, F: FnMut(MemAccess) + Send + Sync> Device for MemSniffer<'a, M, F> {
     fn kind(&self) -> &'static str {
         self.mem.kind()
@@ -66,4 +78,6 @@ impl<'a, M: Memory, F: FnMut(MemAccess)> Memory for MemSniffer<'a, M, F> {
     impl_memsniff_w!(w8, u8);
     impl_memsniff_w!(w16, u16);
     impl_memsniff_w!(w32, u32);
+    impl_memsniff_x!(x16, u16);
+    impl_memsniff_x!(x32, u32);
 }

--- a/clicky-core/src/memory/access.rs
+++ b/clicky-core/src/memory/access.rs
@@ -10,6 +10,7 @@ pub enum MemAccessVal {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MemAccessKind {
     Read,
+    Execute,
     Write,
 }
 
@@ -79,6 +80,17 @@ impl std::fmt::Display for MemAccess {
                     MemAccessVal::U8(_) => "w8",
                     MemAccessVal::U16(_) => "w16",
                     MemAccessVal::U32(_) => "w32",
+                },
+                self.offset,
+                self.val
+            ),
+            MemAccessKind::Execute => write!(
+                f,
+                "{}({:#020x?}, {})",
+                match self.val {
+                    MemAccessVal::U8(_) => "x8",
+                    MemAccessVal::U16(_) => "x16",
+                    MemAccessVal::U32(_) => "x32",
                 },
                 self.offset,
                 self.val

--- a/clicky-core/src/memory/armv4t_adaptor.rs
+++ b/clicky-core/src/memory/armv4t_adaptor.rs
@@ -66,6 +66,31 @@ macro_rules! impl_memadapter_w {
     };
 }
 
+macro_rules! impl_memadapter_x {
+    ($fn:ident, $ret:ty) => {
+        fn $fn(&mut self, addr: u32) -> $ret {
+            use crate::memory::MemAccessKind;
+            match self.mem.$fn(addr) {
+                Ok(val) => val,
+                Err(e) => {
+                    let ret = match e {
+                        // If it's a stubbed-read, pass through the stubbed value
+                        MemException::StubRead(_, v) => v as $ret,
+                        MemException::ContractViolation {
+                            stub_val: Some(v), ..
+                        } => v as $ret,
+                        // otherwise, contents of register undefined
+                        _ => 0x00,
+                    };
+                    // stash the exception
+                    self.exception = Some((ret.to_memaccess(addr, MemAccessKind::Execute), e));
+                    ret
+                }
+            }
+        }
+    };
+}
+
 impl<'a, M: Memory> ArmMemory for MemoryAdapter<'a, M> {
     impl_memadapter_r!(r8, u8);
     impl_memadapter_r!(r16, u16);
@@ -73,4 +98,6 @@ impl<'a, M: Memory> ArmMemory for MemoryAdapter<'a, M> {
     impl_memadapter_w!(w8, u8);
     impl_memadapter_w!(w16, u16);
     impl_memadapter_w!(w32, u32);
+    impl_memadapter_x!(x16, u16);
+    impl_memadapter_x!(x32, u32);
 }

--- a/clicky-core/src/memory/mod.rs
+++ b/clicky-core/src/memory/mod.rs
@@ -16,6 +16,13 @@ pub trait Memory {
     fn r32(&mut self, offset: u32) -> MemResult<u32>;
     /// Write a 32 bit value to the given offset
     fn w32(&mut self, offset: u32, val: u32) -> MemResult<()>;
+    /// Read a 32 bit value at a given offset for execution
+    fn x16(&mut self, offset: u32) -> MemResult<u16> {
+        self.r16(offset)
+    }
+    fn x32(&mut self, offset: u32) -> MemResult<u32> {
+        self.r32(offset)
+    }
 
     /// Read a 8 bit value at a given offset
     fn r8(&mut self, offset: u32) -> MemResult<u8> {
@@ -57,6 +64,7 @@ pub trait Memory {
 macro_rules! impl_memfwd {
     ($type:ty) => {
         impl Memory for $type {
+
             fn r32(&mut self, offset: u32) -> MemResult<u32> {
                 (**self).r32(offset)
             }
@@ -79,6 +87,14 @@ macro_rules! impl_memfwd {
 
             fn w16(&mut self, offset: u32, val: u16) -> MemResult<()> {
                 (**self).w16(offset, val)
+            }
+
+            fn x16(&mut self, offset: u32) -> MemResult<u16> {
+                (**self).x16(offset)
+            }
+
+            fn x32(&mut self, offset: u32) -> MemResult<u32> {
+                (**self).x32(offset)
             }
         }
     };

--- a/clicky-core/src/sys/ipod4g/gdb.rs
+++ b/clicky-core/src/sys/ipod4g/gdb.rs
@@ -83,6 +83,7 @@ impl Ipod4gGdb {
                 match access.kind {
                     MemAccessKind::Read => Event::WatchRead(access.offset),
                     MemAccessKind::Write => Event::WatchWrite(access.offset),
+                    MemAccessKind::Execute => Event::WatchRead(access.offset),
                 },
                 id,
             )));

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -358,6 +358,8 @@ pub struct Ipod4gBus {
     pub firewire: devices::Stub,
     pub total_mystery: devices::Stub,
     pub pwmcon: devices::PWMCon,
+
+    pub pp5002_serial_stub: devices::Stub,
 }
 
 impl Ipod4gBus {
@@ -449,6 +451,8 @@ impl Ipod4gBus {
             firewire: Stub::new("Firewire Con?"),
             total_mystery: Stub::new("<total mystery>"),
             pwmcon: PWMCon::new(),
+
+            pp5002_serial_stub: Stub::new("PP5002 serial stub"),
         }
     }
 }
@@ -617,5 +621,9 @@ mmap! {
         // Diagnostics program writes 0xffffffff
         0xc600_008c => firewire,
         0xffff_fe00..=0xffff_ffff => mystery_flash_stub,
+
+        // PP5002 addresses, I know, but iPodLinux uses that
+        0xc000_6000..=0xc000_6020 => pp5002_serial_stub,
+        0xc000_6040..=0xc000_6060 => pp5002_serial_stub,
     }
 }

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -467,10 +467,10 @@ macro_rules! mmap {
                 fn $fn(&mut self, addr: u32) -> MemResult<$ret> {
                     let mut addr = addr;
                     if (0x00..0x1F).contains(&addr) && self.cachecon.local_evt {
-                        addr |= 0x6000_f100;
+                        addr = addr | 0x6000_f100;
                     }
 
-                    let (addr, prot) = self.memcon.virt_to_phys(addr);
+                    let (mut addr, prot) = self.memcon.virt_to_phys(addr);
                     if !prot.r {
                         return Err(MemException::MmuViolation)
                     }

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -1,7 +1,6 @@
 use std::io::{Read, Seek};
 
 use armv4t_emu::{reg, Cpu};
-use capstone::prelude::*;
 use thiserror::Error;
 
 use crate::block::BlockDev;

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -232,6 +232,9 @@ impl Ipod4g {
                             .write16(devices::ide::IdeReg::Data, val)
                             .unwrap();
                     }
+                    MemAccessKind::Execute => {
+                        panic!("Unsupported execute DMA");
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR contains a handful changes required to boot iPodLinux from ipodloader using a flash dump. I haven't tried creating a proper disk image with iPodLinux's rootfs, this is just the Linux kernel booting and failing to interact properly with the IDE controller.

![Console and GUI output of clicky booting iPodLinux](https://github.com/user-attachments/assets/c8b9550f-adc4-4e00-b8f4-a6a4b31fb63b)
