### PR TITLE
firewire: Rewrite against the OHCI register map

### DIFF
--- a/clicky-core/src/devices/platform/pp/firewire.rs
+++ b/clicky-core/src/devices/platform/pp/firewire.rs
@@ -1,181 +1,181 @@
-// FireWire controller for PP5020. Interfaced to Texas Instruments TSB43AA82 PHY.
-// This peripheral differs from the OG (PP5002) FireWire peripheral as described
-// in iPodLinux sources (mach-ipod/tsb43aa82.{c,h}): base address is different,
-// and register mapping is also very different.
+// FireWire controller for PP5020. Unlike PP5002, PP5020 features its own internal
+// FireWire peripheral.
 //
-// My current understand of the layout for PP5020 is:
-// - +0x000..+0x08b - PP5020 glue registers (undocumented)
-// - +0x08c..+0x188 - TSB43AA82 CFR (CFR 00h lands at +0x08c)
-// - +0x100..+0x1ff - overlaps the above; see the descriptor-array note below
+// Memory mapping is quite close to OHCI, albeit with some usage in a reserved zone.
+// Offsets and bit names below follow the 1394 Open Host Controller Interface
+// spec; Linux's `drivers/ieee1394/ohci1394.h` is a convenient cross-reference.
+// Two values are byte-for-byte what Linux's own driver writes: LinkControlSet
+// gets 0x0030_0000 then 0x0000_0200 (ohci1394.c:530 and :541), and the async
+// contexts are started by writing the run bit to ContextControlSet.
 //
-// But...
-// - +0x100..+0x1ff looks like an array of 8 descriptors on a 0x20 stride, not
-//   CFR: one routine (pc 0x000c0924 / 0x000c0930) writes `+0x0c` then `+0x00` of
-//   entries 4, 6 and 7 during a RetailOS boot. This overlaps where the CFR
-//   would end (+0x188), so the aperture is presumably not just the CFR.
-// - +0x050 takes single-bit writes confined to bits 16..22, each followed by a
-//   read-back. Under this base it is PP glue, not CFR 50h Agent Control.
-// - +0x080/+0x084/+0x088 get written, but map to the read-only ARF/MRF/CRF data
-//   read ports.
+// Only the registers RetailOS and the retail diagnostics actually touch are
+// modelled here. Everything else in the window reads back whatever was last
+// written to it. There's no FireWire bus attached to the emulated iPod, so this
+// only ever needs to be enough to get through boot.
 //
-// So in the end this driver is the bare minimum to get into RetailOS/diags,
-// which is not really an issue since it would be too much trouble forwarding the
-// FireWire trafic to the host.
+// The one range that does *not* fit OHCI is +0x174..+0x17c, which the spec
+// leaves reserved. +0x178 gets a 16-byte aligned pointer into the same region
+// as the self-ID buffer and the DMA descriptors, so it's presumably a
+// PortalPlayer extension.
 
 use crate::devices::prelude::*;
 
-/// Window offset at which the TSB43AA82 CFR appears to start.
-const CFR_BASE: u32 = 0x08c;
-/// The CFR itself is 0x100 bytes (00h..FCh).
-const CFR_LEN: u32 = 0x100;
+mod reg {
+    pub const AT_RETRIES: u32 = 0x008;
+    pub const HC_CONTROL_SET: u32 = 0x050;
+    pub const HC_CONTROL_CLEAR: u32 = 0x054;
+    pub const SELF_ID_BUFFER: u32 = 0x064;
+    pub const INT_EVENT_SET: u32 = 0x080;
+    pub const INT_EVENT_CLEAR: u32 = 0x084;
+    pub const INT_MASK_SET: u32 = 0x088;
+    pub const INT_MASK_CLEAR: u32 = 0x08c;
+    pub const FAIRNESS_CONTROL: u32 = 0x0dc;
+    pub const LINK_CONTROL_SET: u32 = 0x0e0;
+    pub const LINK_CONTROL_CLEAR: u32 = 0x0e4;
+    pub const PHY_CONTROL: u32 = 0x0ec;
+    pub const AS_REQ_FILTER_HI_SET: u32 = 0x100;
+    pub const AS_REQ_FILTER_LO_SET: u32 = 0x108;
 
-#[derive(Debug)]
-enum Endianness {
-    Little,
-    Big,
+    /// Async DMA contexts. Each is a 0x20-byte block: ContextControlSet at
+    /// +0x00, ContextControlClear at +0x04, CommandPtr at +0x0c.
+    pub const AS_REQ_TR_CONTEXT: u32 = 0x180;
+    pub const AS_RSP_TR_CONTEXT: u32 = 0x1a0;
+    pub const AS_REQ_RCV_CONTEXT: u32 = 0x1c0;
+    pub const AS_RSP_RCV_CONTEXT: u32 = 0x1e0;
+
+    pub const CONTEXT_LEN: u32 = 0x20;
+    pub const CONTEXT_CONTROL_SET: u32 = 0x00;
+    pub const CONTEXT_CONTROL_CLEAR: u32 = 0x04;
+    pub const COMMAND_PTR: u32 = 0x0c;
+}
+
+/// `HCControl` bits.
+///
+/// RetailOS brings the link up with the canonical OHCI sequence: softReset,
+/// LPS, postedWriteEnable, linkEnable -- each followed by a read-back.
+mod hc_control {
+    /// Self-clearing. The firmware polls for it to come back down.
+    pub const SOFT_RESET: usize = 16;
+}
+
+/// `PhyControl` (0xec).
+///
+/// The firmware drives it as: write `REG_ADDR` with `RD_REG` set, then spin
+/// until `RD_DONE` comes up and take the result out of `RD_DATA`. Linux does
+/// the identical handshake -- `ohci1394.c:237` polls `PhyControl & 0x80000000`.
+///
+/// RetailOS reads PHY register 5 (a single write of 0x0000_8500); diagnostics
+/// reads PHY register 8 (built up across two writes into 0x0000_8800).
+mod phy_control {
+    use std::ops::RangeInclusive;
+
+    /// PHY register to access.
+    pub const REG_ADDR: RangeInclusive<usize> = 8..=11;
+    /// Kicks off a write. Cleared once the transfer completes.
+    pub const WR_REG: usize = 14;
+    /// Kicks off a read. Cleared once the transfer completes.
+    pub const RD_REG: usize = 15;
+    /// Value read back from the PHY.
+    pub const RD_DATA: RangeInclusive<usize> = 16..=23;
+    /// Address the `RD_DATA` value came from.
+    pub const RD_ADDR: RangeInclusive<usize> = 24..=28;
+    /// Set once a read has completed.
+    pub const RD_DONE: usize = 31;
+}
+
+#[derive(Debug, Default)]
+struct Context {
+    control: u32,
+    /// Bits 3..0 are `Z` (the descriptor count), the rest is the 16-byte
+    /// aligned address of the descriptor block. Nothing ever fetches these,
+    /// since there's no bus to run transfers on.
+    command_ptr: u32,
 }
 
 #[derive(Debug)]
 pub struct Firewire {
-    phy_ctrl: u32,
-    ttcr: u32,
+    hc_control: u32,
+    link_control: u32,
+    int_event: u32,
+    int_mask: u32,
+    phy_control: u32,
+    self_id_buffer: u32,
 
+    /// ATRQ, ATRS, ARRQ, ARRS -- in that order.
+    contexts: [Context; 4],
+
+    /// Backing store for the parts of the window we haven't identified.
     /// The observed window is 0x200 bytes, addressed 1:1.
     reg: Box<[u32; 0x80]>,
-
-    endianness: Endianness,
-}
-
-/// PHY access register (CFR 20h, i.e. window offset 0xac).
-///
-/// Bit positions below are in the ARM's view (i.e. already mirrored out of the
-/// datasheet's MSB-first numbering). Sec 3.4.8.
-///
-/// NOTE: there is no "done" flag. Datasheet bits 16-19 are reserved. `RdPy` /
-/// `WrPy` are self-clearing once the request has been sent, and the result
-/// lands in `RX_ADDR` / `RX_DATA`.
-#[allow(dead_code)]
-mod phyaccess {
-    use std::ops::RangeInclusive;
-
-    /// Read PHY register. Cleared once the request is sent.
-    pub const RD_PHY: usize = 31;
-    /// Write PHY register. Cleared once the request is sent.
-    pub const WR_PHY: usize = 30;
-    /// PHY register to access.
-    pub const ADDR: RangeInclusive<usize> = 24..=27;
-    /// Value to write to the PHY.
-    pub const DATA: RangeInclusive<usize> = 16..=23;
-    /// Address of the PHY register `RX_DATA` came from.
-    pub const RX_ADDR: RangeInclusive<usize> = 8..=11;
-    /// Value read back from the PHY.
-    pub const RX_DATA: RangeInclusive<usize> = 0..=7;
-}
-
-/// CFR 00h reads back as this in little endian mode (sec 3.4.1).
-const VERSION_CHIP_ID_LE: u32 = 0x0382_0043;
-/// ...and byte-reversed in big endian mode. `LYNX_VERSION_CHIP_ID`.
-const VERSION_CHIP_ID_BE: u32 = 0x4300_8203;
-
-/// Name of a CFR register, per the datasheet / iPodLinux's `tsb43aa82.h`.
-fn cfr_name(cfr: u32) -> &'static str {
-    match cfr {
-        0x00 => "CFR:Version",
-        0x04 => "CFR:Misc",
-        0x08 => "CFR:Ctrl",
-        0x0c => "CFR:Interrupt",
-        0x10 => "CFR:IMask",
-        0x14 => "CFR:CycleTimer",
-        0x18 => "CFR:Diagnostic",
-        0x20 => "CFR:PhyAccess",
-        0x24 => "CFR:BusReset",
-        0x28 => "CFR:TimeLimit",
-        0x2c => "CFR:AtfStatus",
-        0x30 => "CFR:ArfStatus",
-        0x34 => "CFR:MtqStatus",
-        0x38 => "CFR:MrfStatus",
-        0x3c => "CFR:CtqStatus",
-        0x40 => "CFR:CrfStatus",
-        0x44 => "CFR:OrbFetchCtrl",
-        0x48 => "CFR:MgmtAgent",
-        0x4c => "CFR:CmdAgent",
-        0x50 => "CFR:AgentCtrl",
-        0x54 => "CFR:OrbPtr1",
-        0x58 => "CFR:OrbPtr2",
-        0x5c => "CFR:AgentStatus",
-        0x60 => "CFR:TxTimerCtrl",
-        0x64 => "CFR:TxTimerStat1",
-        0x68 => "CFR:TxTimerStat2",
-        0x6c => "CFR:TxTimerStat3",
-        0x70 => "CFR:WriteFirst",
-        0x74 => "CFR:WriteContinue",
-        0x78 => "CFR:WriteUpdate",
-        0x80 => "CFR:ArfData",
-        0x84 => "CFR:MrfData",
-        0x88 => "CFR:CrfData",
-        0x8c => "CFR:ConfigRomCtrl",
-        0x90 => "CFR:DmaCtrl",
-        0x94 => "CFR:BiCtrl",
-        0x98 => "CFR:DxfSize",
-        0x9c => "CFR:DxfAvail",
-        0xa0 => "CFR:DxfAck",
-        0xa4 => "CFR:DtfFirstContinue",
-        0xa8 => "CFR:DtfUpdate",
-        0xac => "CFR:DrfData",
-        0xb0..=0xbc => "CFR:DtfCtrl",
-        0xc0..=0xcc => "CFR:DrfCtrl",
-        0xd0..=0xdc => "CFR:DrfHdr",
-        0xe0 => "CFR:DrfTrailer",
-        0xe4 => "CFR:DxfPageCount",
-        0xe8..=0xf4 => "CFR:DxfHdrStat",
-        0xfc => "CFR:LogRomData",
-        _ => "CFR:?",
-    }
 }
 
 impl Firewire {
     pub fn new() -> Firewire {
         Firewire {
-            phy_ctrl: 0,
-            // CFR 60h power-on default (sec 3.4.24). This is load-bearing, not
-            // cosmetic: diagnostics spins forever at pc 0x1000bfb0 waiting on
-            // DTTxEd (datasheet bit 0 -> ARM bit 31). Seeding 0 hangs the boot;
-            // seeding 0x8000_0000 alone is enough to clear the poll.
-            ttcr: 0xFA00_0000,
+            hc_control: 0,
+            link_control: 0,
+            int_event: 0,
+            int_mask: 0,
+            phy_control: 0,
+            self_id_buffer: 0,
+            contexts: Default::default(),
             reg: Box::new([0; 0x80]),
-            endianness: Endianness::Little,
         }
     }
 
-    /// Read a PHY register.
-    ///
-    /// There's no FireWire bus attached to the emulated iPod, so there's
-    /// nothing meaningful to report. Returning zero is the honest answer for a
-    /// disconnected port -- but note it *is* a guess that zero is what real
-    /// silicon gives for each register, rather than something documented.
-    #[allow(dead_code)]
+    /// Read a PHY register. All fields set to zero, because we don't
+    /// want to emulate an actual FireWire host.
     fn read_phy(&self, _addr: u8) -> u8 {
         0
+    }
+
+    /// Map a window offset onto one of the four async DMA contexts, returning
+    /// the context index and the offset within its 0x20-byte block.
+    fn context_at(offset: u32) -> Option<(usize, u32)> {
+        let idx = match offset & !(reg::CONTEXT_LEN - 1) {
+            reg::AS_REQ_TR_CONTEXT => 0,
+            reg::AS_RSP_TR_CONTEXT => 1,
+            reg::AS_REQ_RCV_CONTEXT => 2,
+            reg::AS_RSP_RCV_CONTEXT => 3,
+            _ => return None,
+        };
+
+        Some((idx, offset & (reg::CONTEXT_LEN - 1)))
     }
 }
 
 impl Device for Firewire {
     fn kind(&self) -> &'static str {
-        "Firewire"
+        "Firewire (OHCI)"
     }
 
     fn probe(&self, offset: u32) -> Probe {
-        // Under the +0x08c hypothesis, anything in the CFR aperture gets a real
-        // name. Everything else is presumed to be PP5020 glue, for which there
-        // is no documentation.
+        if let Some((idx, off)) = Firewire::context_at(offset) {
+            let ctx = ["ATRQ", "ATRS", "ARRQ", "ARRS"][idx];
+            return Probe::Register(match off {
+                reg::CONTEXT_CONTROL_SET => ctx,
+                reg::CONTEXT_CONTROL_CLEAR => ctx,
+                reg::COMMAND_PTR => ctx,
+                _ => "(?) context",
+            });
+        }
+
         let reg = match offset {
-            _ if (CFR_BASE..CFR_BASE + CFR_LEN).contains(&offset) => cfr_name(offset - CFR_BASE),
-            0x00 => "PP:Version?",
-            0x08 => "PP:Ctrl?",
-            0x0c => "PP:Interrupt?",
-            0x10 => "PP:IMask?",
-            0x50 => "PP:Reset?",
-            _ => "PP:?",
+            reg::AT_RETRIES => "ATRetries",
+            reg::HC_CONTROL_SET => "HCControlSet",
+            reg::HC_CONTROL_CLEAR => "HCControlClear",
+            reg::SELF_ID_BUFFER => "SelfIDBuffer",
+            reg::INT_EVENT_SET => "IntEventSet",
+            reg::INT_EVENT_CLEAR => "IntEventClear",
+            reg::INT_MASK_SET => "IntMaskSet",
+            reg::INT_MASK_CLEAR => "IntMaskClear",
+            reg::FAIRNESS_CONTROL => "FairnessControl",
+            reg::LINK_CONTROL_SET => "LinkControlSet",
+            reg::LINK_CONTROL_CLEAR => "LinkControlClear",
+            reg::PHY_CONTROL => "PhyControl",
+            reg::AS_REQ_FILTER_HI_SET => "AsReqFilterHiSet",
+            reg::AS_REQ_FILTER_LO_SET => "AsReqFilterLoSet",
+            _ => "(?)",
         };
 
         Probe::Register(reg)
@@ -193,21 +193,27 @@ impl Memory for Firewire {
             return Err(Unexpected);
         }
 
+        if let Some((ctx, off)) = Firewire::context_at(offset) {
+            let val = match off {
+                // The Set and Clear aliases read back the same value.
+                reg::CONTEXT_CONTROL_SET | reg::CONTEXT_CONTROL_CLEAR => self.contexts[ctx].control,
+                reg::COMMAND_PTR => self.contexts[ctx].command_ptr,
+                _ => self.reg[idx],
+            };
+            return Err(StubRead(Debug, val));
+        }
+
         let val = match offset {
-            0x50 => self.phy_ctrl,
-            // CFR 00h. The endianness magic is symmetric under any byte
-            // permutation, so the *write* can't tell us whether the aperture is
-            // byte-swapped -- but this readback can, if the firmware checks it.
-            0x8c => match self.endianness {
-                Endianness::Little => VERSION_CHIP_ID_LE,
-                Endianness::Big => VERSION_CHIP_ID_BE,
-            },
-            // CFR 60h TxTimer Control
-            0xec => self.ttcr,
+            reg::HC_CONTROL_SET | reg::HC_CONTROL_CLEAR => self.hc_control,
+            reg::SELF_ID_BUFFER => self.self_id_buffer,
+            reg::INT_EVENT_SET | reg::INT_EVENT_CLEAR => self.int_event,
+            reg::INT_MASK_SET | reg::INT_MASK_CLEAR => self.int_mask,
+            reg::LINK_CONTROL_SET | reg::LINK_CONTROL_CLEAR => self.link_control,
+            reg::PHY_CONTROL => self.phy_control,
             _ => self.reg[idx],
         };
 
-        Err(StubRead(Info, val))
+        Err(StubRead(Debug, val))
     }
 
     fn w32(&mut self, offset: u32, val: u32) -> MemResult<()> {
@@ -220,24 +226,61 @@ impl Memory for Firewire {
             return Err(Unexpected);
         }
 
-        self.reg[idx] = val;
-
-        match offset {
-            0x50 => self.phy_ctrl = val, // iPodLinux says its for reset
-
-            // CFR 00h Version/Revision -- doubles as the endianness control.
-            0x8c => match val {
-                0x0000_0000 => self.endianness = Endianness::Little,
-                0xffff_ffff => self.endianness = Endianness::Big,
-                _ => {}
-            },
-
-            // CFR 60h TxTimer Control
-            0xec => self.ttcr = val,
-
-            _ => {}
+        if let Some((ctx, off)) = Firewire::context_at(offset) {
+            match off {
+                reg::CONTEXT_CONTROL_SET => self.contexts[ctx].control |= val,
+                reg::CONTEXT_CONTROL_CLEAR => self.contexts[ctx].control &= !val,
+                reg::COMMAND_PTR => self.contexts[ctx].command_ptr = val,
+                _ => self.reg[idx] = val,
+            }
+            return Err(StubWrite(Debug, ()));
         }
 
-        Err(StubWrite(Info, ()))
+        match offset {
+            reg::HC_CONTROL_SET => {
+                self.hc_control |= val;
+                // softReset never stays set: the reset completes instantly, and
+                // the firmware polls for the bit to come back down.
+                self.hc_control.set_bit(hc_control::SOFT_RESET, false);
+            }
+            reg::HC_CONTROL_CLEAR => self.hc_control &= !val,
+
+            reg::SELF_ID_BUFFER => self.self_id_buffer = val,
+
+            reg::INT_EVENT_SET => self.int_event |= val,
+            reg::INT_EVENT_CLEAR => self.int_event &= !val,
+            reg::INT_MASK_SET => self.int_mask |= val,
+            reg::INT_MASK_CLEAR => self.int_mask &= !val,
+
+            reg::LINK_CONTROL_SET => self.link_control |= val,
+            reg::LINK_CONTROL_CLEAR => self.link_control &= !val,
+
+            reg::PHY_CONTROL => {
+                let mut val = val;
+
+                // Transfers complete instantly: there's no bus to arbitrate
+                // for, so there's nothing to make the firmware wait on. Leaving
+                // RD_DONE clear instead would wedge it -- diagnostics spins on
+                // that bit at pc 0x1000bfb0 with no timeout.
+                if val.get_bit(phy_control::RD_REG) {
+                    let addr = val.get_bits(phy_control::REG_ADDR) as u8;
+                    let data = self.read_phy(addr);
+
+                    val.set_bit(phy_control::RD_REG, false)
+                        .set_bits(phy_control::RD_ADDR, addr as u32)
+                        .set_bits(phy_control::RD_DATA, data as u32)
+                        .set_bit(phy_control::RD_DONE, true);
+                }
+
+                // Writes to the PHY go nowhere, but the bit still has to clear.
+                val.set_bit(phy_control::WR_REG, false);
+
+                self.phy_control = val;
+            }
+
+            _ => self.reg[idx] = val,
+        }
+
+        Err(StubWrite(Debug, ()))
     }
 }


### PR DESCRIPTION
Unlike the PP5002, which drives an external TI TSB43AA82, the PP5020 has its own on-chip link layer controller (cf. PP5020 databrief). Its register layout is closely matching OHCI.