### PR TITLE
Misc clippy fixes

### DIFF
--- a/clicky-core/src/devices/platform/pp/i2c.rs
+++ b/clicky-core/src/devices/platform/pp/i2c.rs
@@ -177,7 +177,7 @@ impl I2CCon {
         device: Box<dyn I2CDevice>,
     ) -> Option<Box<dyn I2CDevice>> {
         assert!(addr < 128, "i2c addresses cannt be greater than 127!");
-        std::mem::replace(&mut self.devices[addr as usize], Some(device))
+        self.devices[addr as usize].replace(device)
     }
 
     // TODO?: This could be an async op (setting the busy flag + un-setting

--- a/clicky-core/src/devices/util/arcmutex.rs
+++ b/clicky-core/src/devices/util/arcmutex.rs
@@ -27,7 +27,7 @@ impl<D> ArcMutexDevice<D> {
     }
 
     /// Lock the underlying device
-    pub fn lock(&self) -> LockResult<MutexGuard<D>> {
+    pub fn lock(&self) -> LockResult<MutexGuard<'_, D>> {
         self.device.lock()
     }
 }

--- a/clicky-core/src/sys/ipod4g/gdb.rs
+++ b/clicky-core/src/sys/ipod4g/gdb.rs
@@ -253,7 +253,7 @@ impl MultiThreadOps for Ipod4gGdb {
                 let mut cycles: usize = 0;
                 loop {
                     // check for GDB interrupt every 1024 instructions
-                    if cycles % 1024 == 0 && check_gdb_interrupt() {
+                    if cycles.is_multiple_of(1024) && check_gdb_interrupt() {
                         return Ok(ThreadStopReason::GdbInterrupt);
                     }
                     cycles += 1;

--- a/clicky-core/src/sys/ipod4g/gdb.rs
+++ b/clicky-core/src/sys/ipod4g/gdb.rs
@@ -208,19 +208,19 @@ impl Target for Ipod4gGdb {
     type Arch = arch::arm::Armv4t;
     type Error = FatalMemException;
 
-    fn base_ops(&mut self) -> target::ext::base::BaseOps<Self::Arch, Self::Error> {
+    fn base_ops(&mut self) -> target::ext::base::BaseOps<'_, Self::Arch, Self::Error> {
         target::ext::base::BaseOps::MultiThread(self)
     }
 
-    fn sw_breakpoint(&mut self) -> Option<target::ext::breakpoints::SwBreakpointOps<Self>> {
+    fn sw_breakpoint(&mut self) -> Option<target::ext::breakpoints::SwBreakpointOps<'_, Self>> {
         Some(self)
     }
 
-    fn hw_watchpoint(&mut self) -> Option<target::ext::breakpoints::HwWatchpointOps<Self>> {
+    fn hw_watchpoint(&mut self) -> Option<target::ext::breakpoints::HwWatchpointOps<'_, Self>> {
         Some(self)
     }
 
-    fn monitor_cmd(&mut self) -> Option<target::ext::monitor_cmd::MonitorCmdOps<Self>> {
+    fn monitor_cmd(&mut self) -> Option<target::ext::monitor_cmd::MonitorCmdOps<'_, Self>> {
         Some(self)
     }
 }

--- a/clicky-core/src/sys/ipod4g/mod.rs
+++ b/clicky-core/src/sys/ipod4g/mod.rs
@@ -519,7 +519,7 @@ macro_rules! mmap {
                 fn $fn(&mut self, addr: u32) -> MemResult<$ret> {
                     let mut addr = addr;
                     if (0x00..0x1F).contains(&addr) && self.cachecon.local_evt {
-                        addr = addr | 0x6000_f100;
+                        addr |= 0x6000_f100;
                     }
 
                     let (phys_addr, prot) = self.memcon.virt_to_phys(addr, MemAccessKind::Read);


### PR DESCRIPTION
* Explicit lifetimes
* In-place OR operator
* is_multiple_of
* .replace() on array instead of calling std::mem::replace